### PR TITLE
Add support for parsing deflated datasets 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler32"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ahash"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +264,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +470,7 @@ name = "dcmpipe_lib"
 version = "0.1.0"
 dependencies = [
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libflate 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -886,6 +900,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libc"
 version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libflate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libflate_lz77 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1521,6 +1551,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,6 +2165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum addr2line 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b"
+"checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6f33b5018f120946c1dcf279194f238a9f146725593ead1c08fa47ff22b0b5d3"
 "checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
@@ -2160,6 +2196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum const-random 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
 "checksum const-random-macro 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
+"checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
 "checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 "checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
@@ -2225,6 +2262,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum kv-log-macro 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2a2d3beed37e5483887d81eb39de6de03a8346531410e1306ca48a9a89bd3a51"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)" = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
+"checksum libflate 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1fbe6b967a94346446d37ace319ae85be7eca261bb8149325811ac435d35d64"
+"checksum libflate_lz77 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
 "checksum linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 "checksum lock_api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
@@ -2296,6 +2335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 "checksum resolv-conf 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "11834e137f3b14e309437a8276714eed3a80d1ef894869e510f2c0c0b98b9f4a"
 "checksum ring 0.16.13 (registry+https://github.com/rust-lang/crates.io-index)" = "703516ae74571f24b465b4a1431e81e2ad51336cb0ded733a55a1aa3eccac196"
+"checksum rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
 "checksum rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"

--- a/dcmpipe_cli/Cargo.toml
+++ b/dcmpipe_cli/Cargo.toml
@@ -11,7 +11,7 @@ crossterm = "0.17"
 cursive = { version = "0.14", default-features = false, features = ["crossterm-backend"] }
 cursive_table_view = "0.12"
 dcmpipe_dict = { path = "../dcmpipe_dict", version = "0.1" }
-dcmpipe_lib = { path = "../dcmpipe_lib", version = "0.1" }
+dcmpipe_lib = { path = "../dcmpipe_lib", version = "0.1", features = ["deflate"] }
 mongodb = { version = "0.10", default-features = false, features = ["sync"] }
 structopt = "0.3"
 walkdir = "2.3"

--- a/dcmpipe_lib/Cargo.toml
+++ b/dcmpipe_lib/Cargo.toml
@@ -4,9 +4,14 @@ version = "0.1.0"
 authors = ["neandrake <die.drachen@gmail.com>"]
 edition = "2018"
 
+[features]
+deflate = ["libflate"]
+
 [dependencies]
 encoding = "0.2"
 thiserror = "1.0"
+
+libflate = { version="1.0", optional=true }
 
 [lib]
 name="dcmpipe_lib"

--- a/dcmpipe_lib/src/core/dcmparser.rs
+++ b/dcmpipe_lib/src/core/dcmparser.rs
@@ -17,7 +17,6 @@ use crate::defn::ts::TSRef;
 use crate::defn::vl::ValueLength;
 use crate::defn::vr::{self, VRRef};
 
-
 pub const FILE_PREAMBLE_LENGTH: usize = 128;
 pub const DICOM_PREFIX_LENGTH: usize = 4;
 const MAX_VALUE_LENGTH_IN_DETECT: u32 = 100;

--- a/dcmpipe_tests/Cargo.toml
+++ b/dcmpipe_tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 dcmpipe_dict = { path = "../dcmpipe_dict", version = "0.1" }
-dcmpipe_lib = { path = "../dcmpipe_lib", version = "0.1" }
+dcmpipe_lib = { path = "../dcmpipe_lib", version = "0.1", features = ["deflate"] }
 encoding = "0.2"
 walkdir = "2.3"
 

--- a/dcmpipe_tests/src/parsing.rs
+++ b/dcmpipe_tests/src/parsing.rs
@@ -108,12 +108,12 @@ fn test_unknown_explicit_vr_is_error() {
 
     match first_elem {
         Ok(_) => {
-            assert!(false);
+            panic!("first element after SpecificCharacterSet should not parse");
         }
         Err(ParseError::UnknownExplicitVR(code)) => {
             assert_eq!(code, 0);
         }
-        Err(_) => assert!(false),
+        Err(e) => panic!("unexpected error: {:?}", e),
     }
 }
 
@@ -1164,13 +1164,11 @@ fn test_dicomdir(with_std: bool) -> Result<()> {
 }
 
 #[test]
-#[ignore] // this is a deflated dataset
 fn test_sq_with_undefined_length_converted_to_defined_length_with_std() -> Result<()> {
     test_sq_with_undefined_length_converted_to_defined_length(true)
 }
 
 #[test]
-#[ignore] // this is a deflated dataset
 fn test_sq_with_undefined_length_converted_to_defined_length_without_std() -> Result<()> {
     test_sq_with_undefined_length_converted_to_defined_length(false)
 }
@@ -1182,13 +1180,11 @@ fn test_sq_with_undefined_length_converted_to_defined_length(with_std: bool) -> 
 }
 
 #[test]
-#[ignore]
 fn test_sq_with_undefined_length_unconvertable_to_defined_length_with_std() -> Result<()> {
     test_sq_with_undefined_length_unconvertable_to_defined_length(true)
 }
 
 #[test]
-#[ignore]
 fn test_sq_with_undefined_length_unconvertable_to_defined_length_without_std() -> Result<()> {
     test_sq_with_undefined_length_unconvertable_to_defined_length(false)
 }


### PR DESCRIPTION
Using the `libflate` crate the dataset stream can be wrapped in a
`Decoder` to enable reading deflated datasets. The file-meta section of
a file dataset is not deflated, so this should only be toggled on during
the `ParseState::Element` parsing.

To accomplish the flip from reading uncompressed to compressed data is
accomplished by having the dataset initialized in a `Decoder` and
conditionally accessing the inner stream reference when needing to read
uncompressed. This penalizes all parsing with an extra indirection and
conditional when reading bytes however this should be negligible as most
parsing should be I/O bound and not CPU bound.

In keeping with the crate's goal of being minimal, support for deflation
is set up as a non-default crate feature. Users of the crate will have
to opt-in if they want support for deflated datasets.

Without support for deflated datasets the dataset is now also wrapped in
a `BufReader` and `ParserBuilder` allows specifying the buffer size.