### PR TITLE
feat: split out request/response handling to enable async support

### DIFF
--- a/dcmpipe_cli/src/app/mod.rs
+++ b/dcmpipe_cli/src/app/mod.rs
@@ -138,10 +138,7 @@ fn rename_file_to_sop(filename: &str, ts: TSRef) -> Result<(), DimseError> {
                 .and_then(|v| v.string().cloned())
         });
     let Some(sop_uid) = sop_uid else {
-        return Err(DimseError::SOPInstanceUIDMissing(
-            usize::try_from(parser.bytes_read()).unwrap_or_default(),
-            filename.to_owned(),
-        ));
+        return Err(DimseError::DimseElementMissing(filename.to_owned()));
     };
     drop(parser);
     std::fs::rename(filename, format!("{sop_uid}.dcm")).map_err(DimseError::from)?;

--- a/dcmpipe_cli/src/app/mod.rs
+++ b/dcmpipe_cli/src/app/mod.rs
@@ -123,7 +123,7 @@ fn handle_assoc_result<W: Write>(
 /// # Errors
 /// - I/O errors may occur reading or renaming the file.
 /// - `DimseError` will occur if the file could not be parsed as DICOM or did not contain a SOP
-/// Instance UID.
+///   Instance UID.
 fn rename_file_to_sop(filename: &str, ts: TSRef) -> Result<(), DimseError> {
     let file = BufReader::with_capacity(8 * 1024, File::open(filename).map_err(DimseError::from)?);
     let mut parser = ParserBuilder::default()

--- a/dcmpipe_cli/src/app/scpapp.rs
+++ b/dcmpipe_cli/src/app/scpapp.rs
@@ -40,7 +40,7 @@ use dcmpipe_lib::{
         commands::{messages::CommandMessage, CommandStatus, CommandType, SubOpProgress},
         error::{AssocError, DimseError},
         pdus::PduType,
-        svcops::{EchoSvcOp, FindSvcOp, GetSvcOp},
+        svcops::AssocSvcOp,
     },
 };
 use std::{
@@ -137,10 +137,8 @@ impl CommandApplication for SvcProviderApp {
 pub(crate) type Stat = CommandStatus;
 
 /// Convenience to create `Err(AssocError::ab_failure(DimseError::GeneralError(msg)))`.
-pub(crate) fn fail(msg: &str) -> Result<(), AssocError> {
-    Err(AssocError::ab_failure(DimseError::ApplicationError(
-        msg.into(),
-    )))
+pub(crate) fn fail(msg: &str) -> AssocError {
+    AssocError::ab_failure(DimseError::ApplicationError(msg.into()))
 }
 
 /// Convenience to create a `SubOpProgress`.
@@ -248,29 +246,31 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
                 continue;
             }
 
-            // TODO: Add 'op' to a map for tracking incomplete ops.
-            if cmd.cmd_type() == &CommandType::CEchoReq {
-                let mut op = EchoSvcOp::new(cmd.msg_id());
-                self.handle_c_echo_req(&mut op, &cmd)?;
-                println!("[info ->]: {:?}", CommandType::CEchoRsp);
-            } else if cmd.cmd_type() == &CommandType::CFindReq {
-                let mut op = FindSvcOp::new(cmd.msg_id());
-                self.handle_c_find_req(&mut op, &cmd)?;
-                println!("[info ->]: {:?}", CommandType::CFindRsp);
-            } else if cmd.cmd_type() == &CommandType::CStoreReq {
-                self.handle_c_store_req(&cmd)?;
-                println!("[info ->]: {:?}", CommandType::CStoreRsp);
-            } else if cmd.cmd_type() == &CommandType::CMoveReq {
-                self.handle_c_move_req(&cmd)?;
-                println!("[info ->]: {:?}", CommandType::CMoveRsp);
-            } else if cmd.cmd_type() == &CommandType::CGetReq {
-                let mut op = GetSvcOp::new(cmd.msg_id());
-                self.handle_c_get_req(&mut op, &cmd)?;
-                println!("[info ->]: {:?}", CommandType::CGetRsp);
-            } else {
-                return Err(AssocError::ab_failure(DimseError::UnexpectedCommandType(
-                    cmd.cmd_type().clone(),
-                )));
+            let Some(op) = self.assoc.common_mut().recv_req(&cmd)? else {
+                continue;
+            };
+
+            match op {
+                AssocSvcOp::Echo(op) => {
+                    self.handle_c_echo_req(&mut op, &cmd)?;
+                    println!("[info ->]: {:?}", CommandType::CEchoRsp);
+                }
+                AssocSvcOp::Find(op) => {
+                    self.handle_c_find_req(&mut op, &cmd)?;
+                    println!("[info ->]: {:?}", CommandType::CFindRsp);
+                }
+                AssocSvcOp::Get(op) => {
+                    self.handle_c_get_req(&mut op, &cmd)?;
+                    println!("[info ->]: {:?}", CommandType::CGetRsp);
+                }
+                AssocSvcOp::Move(op) => {
+                    self.handle_c_move_req(&mut op, &cmd)?;
+                    println!("[info ->]: {:?}", CommandType::CMoveRsp);
+                }
+                AssocSvcOp::Store(op) => {
+                    self.handle_c_store_req(&mut op, &cmd)?;
+                    println!("[info ->]: {:?}", CommandType::CStoreRsp);
+                }
             }
         }
     }
@@ -305,14 +305,14 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
         store_rsp: Result<DimseMsg, AssocError>,
         stat_rpt: &StatusMsgBuilder,
         progress: &SubOpProgress,
-    ) -> Result<(), AssocError> {
+    ) -> Result<CommandMessage, AssocError> {
         let cmd_rsp = match store_rsp {
             Ok(DimseMsg::Cmd(cmd)) => cmd,
             Ok(rp) => {
                 self.assoc
                     .common()
                     .write_command(&stat_rpt.msg(&Stat::fail(), progress), &mut self.writer)?;
-                return fail(&format!("Sub-operation C-STORE failed: {rp:?}"));
+                return Err(fail(&format!("Sub-operation C-STORE failed: {rp:?}")));
             }
             Err(e) => {
                 self.assoc
@@ -326,9 +326,9 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
             self.assoc
                 .common()
                 .write_command(&stat_rpt.msg(&Stat::fail(), progress), &mut self.writer)?;
-            return fail(&format!("Sub-operation C-STORE failed: {cmd_rsp:?}"));
+            return Err(fail(&format!("Sub-operation C-STORE failed: {cmd_rsp:?}")));
         }
 
-        Ok(())
+        Ok(cmd_rsp)
     }
 }

--- a/dcmpipe_cli/src/app/scpapp/cecho.rs
+++ b/dcmpipe_cli/src/app/scpapp/cecho.rs
@@ -25,10 +25,11 @@ use crate::app::scpapp::AssociationDevice;
 impl<R: Read, W: Write> AssociationDevice<R, W> {
     pub(crate) fn handle_c_echo_req(
         &mut self,
-        op: &mut EchoSvcOp,
+        mut op: EchoSvcOp,
         cmd: &CommandMessage,
     ) -> Result<(), AssocError> {
+        let pdu_max_snd_size = self.assoc.common().get_pdu_max_snd_size();
         let rsp = op.process_req(cmd)?;
-        op.write_response(&rsp, self.assoc.common(), &mut self.writer)
+        op.write_response(&rsp, &mut self.writer, pdu_max_snd_size)
     }
 }

--- a/dcmpipe_cli/src/app/scpapp/cecho.rs
+++ b/dcmpipe_cli/src/app/scpapp/cecho.rs
@@ -30,6 +30,6 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
     ) -> Result<(), AssocError> {
         let pdu_max_snd_size = self.assoc.common().get_pdu_max_snd_size();
         let rsp = op.process_req(cmd)?;
-        op.write_response(&rsp, &mut self.writer, pdu_max_snd_size)
+        op.end_response(&rsp, &mut self.writer, pdu_max_snd_size)
     }
 }

--- a/dcmpipe_cli/src/app/scpapp/cfind.rs
+++ b/dcmpipe_cli/src/app/scpapp/cfind.rs
@@ -52,7 +52,7 @@ use dcmpipe_lib::{
     },
     dimse::{
         assoc::QueryLevel,
-        commands::messages::CommandMessage,
+        commands::{messages::CommandMessage, CommandStatus},
         error::{AssocError, DimseError},
         svcops::FindSvcOp,
     },
@@ -157,7 +157,14 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
             &query_results.group_map,
         )?;
 
-        op.write_response(self.assoc.common(), &mut self.writer, &dcm_results)?;
+        for (i, result) in dcm_results.iter().enumerate() {
+            let status = if i == dcm_results.len() - 1 {
+                CommandStatus::success()
+            } else {
+                CommandStatus::pending()
+            };
+            op.write_response(self.assoc.common(), &mut self.writer, result, &status)?;
+        }
 
         Ok(())
     }

--- a/dcmpipe_cli/src/app/scpapp/cfind.rs
+++ b/dcmpipe_cli/src/app/scpapp/cfind.rs
@@ -158,16 +158,19 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
             &query_results.group_map,
         )?;
 
-        // TODO: self.assoc.common_mut().add_svc_op(op)
-
-        for (i, result) in dcm_results.iter().enumerate() {
-            let status = if i == dcm_results.len() - 1 {
-                CommandStatus::success()
-            } else {
-                CommandStatus::pending()
-            };
-            op.write_response(&mut self.writer, pdu_max_snd_size, result, &status)?;
+        for result in dcm_results.iter() {
+            op.write_response(
+                &mut self.writer,
+                pdu_max_snd_size,
+                result,
+                &CommandStatus::pending(),
+            )?;
         }
+        op.end_response(
+            &mut self.writer,
+            pdu_max_snd_size,
+            &CommandStatus::success(),
+        )?;
 
         Ok(())
     }

--- a/dcmpipe_cli/src/app/scpapp/cget.rs
+++ b/dcmpipe_cli/src/app/scpapp/cget.rs
@@ -38,12 +38,8 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
         op: &mut GetSvcOp,
         cmd: &CommandMessage,
     ) -> Result<(), AssocError> {
-        let dcm_query = op.process_req(
-            cmd,
-            self.assoc.common(),
-            &mut self.reader,
-            &mut self.writer,
-        )?;
+        let dcm_query =
+            op.process_req(cmd, self.assoc.common(), &mut self.reader, &mut self.writer)?;
         let statter = StatusMsgBuilder::new(
             false,
             op.ctx_id(),

--- a/dcmpipe_cli/src/app/scpapp/cmove.rs
+++ b/dcmpipe_cli/src/app/scpapp/cmove.rs
@@ -22,10 +22,7 @@ use std::{
 
 use dcmpipe_lib::{
     core::read::ParserBuilder,
-    dict::{
-        stdlookup::STANDARD_DICOM_DICTIONARY,
-        tags::{AffectedSOPClassUID, MessageID, MoveDestination},
-    },
+    dict::stdlookup::STANDARD_DICOM_DICTIONARY,
     dimse::{
         assoc::{
             scu::{UserAssoc, UserAssocBuilder},
@@ -33,25 +30,25 @@ use dcmpipe_lib::{
         },
         commands::messages::CommandMessage,
         error::{AssocError, DimseError},
+        svcops::MoveSvcOp,
     },
 };
 
 use crate::app::scpapp::{fail, prog, AssociationDevice, Stat, StatusMsgBuilder};
 
 impl<R: Read, W: Write> AssociationDevice<R, W> {
-    pub(crate) fn handle_c_move_req(&mut self, cmd: &CommandMessage) -> Result<(), AssocError> {
-        let ctx_id = cmd.ctx_id();
-        let msg_id = cmd.get_ushort(&MessageID).map_err(AssocError::ab_failure)?;
-        let aff_sop_class = cmd
-            .get_string(&AffectedSOPClassUID)
-            .map_err(AssocError::ab_failure)?;
-
-        let statter = StatusMsgBuilder::new(true, ctx_id, msg_id, aff_sop_class);
-
-        let dest = cmd
-            .get_string(&MoveDestination)
-            .map_err(AssocError::ab_failure)?;
-        let Some(aet_host) = self.assoc.aet_host(&dest).cloned() else {
+    pub(crate) fn handle_c_move_req(
+        &mut self,
+        op: &mut MoveSvcOp,
+        cmd: &CommandMessage,
+    ) -> Result<(), AssocError> {
+        let statter = StatusMsgBuilder::new(
+            true,
+            op.ctx_id(),
+            op.msg_id(),
+            op.aff_sop_class().to_owned(),
+        );
+        let Some(aet_host) = self.assoc.aet_host(op.aet_dest()).cloned() else {
             // Report failed progress to C-MOVE requestor. The query for matching SOPs happens
             // after validating the AE title so we can't report any numbers for progress.
             self.assoc.common().write_command(
@@ -59,15 +56,12 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
                 &mut self.writer,
             )?;
             return Err(AssocError::ab_failure(DimseError::InvalidCallingAeTitle(
-                dest,
+                op.aet_dest().to_owned(),
             )));
         };
 
-        let (_pres_ctx, ts) = self.assoc.common().get_pres_ctx_and_ts(ctx_id)?;
         let dcm_query =
-            self.assoc
-                .common()
-                .read_dataset_in_mem(&mut self.reader, &mut self.writer, ts)?;
+            op.process_req(cmd, self.assoc.common(), &mut self.reader, &mut self.writer)?;
 
         let query_results = self.query_database(&dcm_query)?;
         let path_map = Self::resolve_to_paths(query_results.group_map);
@@ -75,25 +69,30 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
         let sop_count = path_map.values().map(Vec::len).sum::<usize>();
         let sop_count = u16::try_from(sop_count).unwrap_or_default();
 
-        self.assoc.common().write_command(
-            &statter.msg(&Stat::pending(), &prog(sop_count, 0, 0, 0)),
+        op.write_response(
+            self.assoc.common(),
             &mut self.writer,
+            &Stat::pending(),
+            &prog(sop_count, 0, 0, 0),
         )?;
 
-        let mut scu_assoc = self.create_sub_assoc(&dest);
+        let mut scu_assoc = self.create_sub_assoc(op.aet_dest());
 
         let stream = TcpStream::connect(aet_host)
             .map_err(|e| AssocError::ab_failure(DimseError::IOError(e)))?;
         let mut dest_reader = BufReader::new(&stream);
         let mut dest_writer = BufWriter::new(&stream);
         if let Some(msg) = scu_assoc.request_association(&mut dest_reader, &mut dest_writer)? {
-            self.assoc.common().write_command(
-                &statter.msg(&Stat::fail(), &prog(0, 0, sop_count, 0)),
+            op.write_response(
+                self.assoc.common(),
                 &mut self.writer,
+                &Stat::fail(),
+                &prog(0, 0, sop_count, 0),
             )?;
-            return fail(&format!(
-                "Association to {dest} failed with response: {msg:?}"
-            ));
+            return Err(fail(&format!(
+                "Association to {} failed with response: {msg:?}",
+                op.aet_dest()
+            )));
         }
 
         let mut successful: u16 = 0;
@@ -113,7 +112,7 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
                             &statter.msg(&Stat::fail(), &prog(0, successful, remaining, 0)),
                             &mut self.writer,
                         )?;
-                        return fail(&format!("Failed resolving {path:?}"));
+                        return Err(fail(&format!("Failed resolving {path:?}")));
                     }
                 };
 
@@ -126,7 +125,7 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
                     parser,
                     store_msg_id,
                     self.assoc.common().this_ae(),
-                    msg_id,
+                    op.msg_id(),
                 )?;
 
                 let store_rsp = CommonAssoc::next_msg(
@@ -147,9 +146,11 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
                 successful += 1;
                 remaining -= 1;
 
-                if let Err(e) = self.assoc.common().write_command(
-                    &statter.msg(&Stat::pending(), &prog(remaining, successful, 0, 0)),
+                if let Err(e) = op.write_response(
+                    self.assoc.common(),
                     &mut self.writer,
+                    &Stat::pending(),
+                    &prog(remaining, successful, 0, 0),
                 ) {
                     // Create error to abort the sub-association but return the original error.
                     let _ =
@@ -163,9 +164,11 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
         // If there's an error releasing the association don't propagate as an error.
         let _ = scu_assoc.release_association(&mut dest_reader, &mut dest_writer);
 
-        self.assoc.common().write_command(
-            &statter.msg(&Stat::success(), &prog(remaining, successful, 0, 0)),
+        op.write_response(
+            self.assoc.common(),
             &mut self.writer,
+            &Stat::success(),
+            &prog(remaining, successful, 0, 0),
         )?;
         Ok(())
     }

--- a/dcmpipe_cli/src/app/scpapp/cmove.rs
+++ b/dcmpipe_cli/src/app/scpapp/cmove.rs
@@ -58,7 +58,9 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
                 &statter.msg(&Stat::fail_unknown_dest(), &prog(0, 0, 0, 0)),
                 &mut self.writer,
             )?;
-            return Err(AssocError::ab_failure(DimseError::InvalidAeTitle(dest)));
+            return Err(AssocError::ab_failure(DimseError::InvalidCallingAeTitle(
+                dest,
+            )));
         };
 
         let (_pres_ctx, ts) = self.assoc.common().get_pres_ctx_and_ts(ctx_id)?;

--- a/dcmpipe_cli/src/app/scpapp/cmove.rs
+++ b/dcmpipe_cli/src/app/scpapp/cmove.rs
@@ -39,7 +39,7 @@ use crate::app::scpapp::{fail, prog, AssociationDevice, Stat, StatusMsgBuilder};
 impl<R: Read, W: Write> AssociationDevice<R, W> {
     pub(crate) fn handle_c_move_req(
         &mut self,
-        op: &mut MoveSvcOp,
+        mut op: MoveSvcOp,
         cmd: &CommandMessage,
     ) -> Result<(), AssocError> {
         let statter = StatusMsgBuilder::new(
@@ -51,9 +51,10 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
         let Some(aet_host) = self.assoc.aet_host(op.aet_dest()).cloned() else {
             // Report failed progress to C-MOVE requestor. The query for matching SOPs happens
             // after validating the AE title so we can't report any numbers for progress.
-            self.assoc.common().write_command(
+            CommonAssoc::write_command(
                 &statter.msg(&Stat::fail_unknown_dest(), &prog(0, 0, 0, 0)),
                 &mut self.writer,
+                self.assoc.common().get_pdu_max_snd_size(),
             )?;
             return Err(AssocError::ab_failure(DimseError::InvalidCallingAeTitle(
                 op.aet_dest().to_owned(),
@@ -70,8 +71,8 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
         let sop_count = u16::try_from(sop_count).unwrap_or_default();
 
         op.write_response(
-            self.assoc.common(),
             &mut self.writer,
+            self.assoc.common().get_pdu_max_snd_size(),
             &Stat::pending(),
             &prog(sop_count, 0, 0, 0),
         )?;
@@ -84,8 +85,8 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
         let mut dest_writer = BufWriter::new(&stream);
         if let Some(msg) = scu_assoc.request_association(&mut dest_reader, &mut dest_writer)? {
             op.write_response(
-                self.assoc.common(),
                 &mut self.writer,
+                self.assoc.common().get_pdu_max_snd_size(),
                 &Stat::fail(),
                 &prog(0, 0, sop_count, 0),
             )?;
@@ -108,9 +109,10 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
                         let _ = err.write(&mut dest_writer);
 
                         // For now, if one fails then do not attempt the rest.
-                        self.assoc.common().write_command(
+                        CommonAssoc::write_command(
                             &statter.msg(&Stat::fail(), &prog(0, successful, remaining, 0)),
                             &mut self.writer,
+                            self.assoc.common().get_pdu_max_snd_size(),
                         )?;
                         return Err(fail(&format!("Failed resolving {path:?}")));
                     }
@@ -147,8 +149,8 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
                 remaining -= 1;
 
                 if let Err(e) = op.write_response(
-                    self.assoc.common(),
                     &mut self.writer,
+                    self.assoc.common().get_pdu_max_snd_size(),
                     &Stat::pending(),
                     &prog(remaining, successful, 0, 0),
                 ) {
@@ -165,8 +167,8 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
         let _ = scu_assoc.release_association(&mut dest_reader, &mut dest_writer);
 
         op.write_response(
-            self.assoc.common(),
             &mut self.writer,
+            self.assoc.common().get_pdu_max_snd_size(),
             &Stat::success(),
             &prog(remaining, successful, 0, 0),
         )?;

--- a/dcmpipe_cli/src/app/scpapp/cstore.rs
+++ b/dcmpipe_cli/src/app/scpapp/cstore.rs
@@ -16,23 +16,21 @@
 
 use std::io::{Read, Write};
 
-use dcmpipe_lib::{
-    dict::tags::{AffectedSOPClassUID, MessageID},
-    dimse::{
-        commands::{messages::CommandMessage, CommandStatus},
-        error::AssocError,
-    },
+use dcmpipe_lib::dimse::{
+    commands::{messages::CommandMessage, CommandStatus},
+    error::AssocError,
+    svcops::StoreSvcOp,
 };
 
 use crate::app::scpapp::AssociationDevice;
 
 impl<R: Read, W: Write> AssociationDevice<R, W> {
-    pub(crate) fn handle_c_store_req(&mut self, cmd: &CommandMessage) -> Result<(), AssocError> {
-        let ctx_id = cmd.ctx_id();
-        let msg_id = cmd.get_ushort(&MessageID).map_err(AssocError::ab_failure)?;
-        let aff_sop_class = cmd
-            .get_string(&AffectedSOPClassUID)
-            .map_err(AssocError::ab_failure)?;
+    pub(crate) fn handle_c_store_req(
+        &mut self,
+        op: &mut StoreSvcOp,
+        cmd: &CommandMessage,
+    ) -> Result<(), AssocError> {
+        op.process_req(cmd)?;
 
         // TODO: Tuck this away somewhere. Add appropriate FileMeta elements.
         let mut empty = std::io::empty();
@@ -40,10 +38,10 @@ impl<R: Read, W: Write> AssociationDevice<R, W> {
             .common()
             .read_dataset(&mut self.reader, &mut self.writer, &mut empty)?;
 
-        let cmd =
-            CommandMessage::c_store_rsp(ctx_id, msg_id, &aff_sop_class, &CommandStatus::success());
-        self.assoc.common().write_command(&cmd, &mut self.writer)?;
-
-        Ok(())
+        op.write_response(
+            self.assoc.common(),
+            &mut self.writer,
+            &CommandStatus::success(),
+        )
     }
 }

--- a/dcmpipe_cli/src/app/scuapp.rs
+++ b/dcmpipe_cli/src/app/scuapp.rs
@@ -113,113 +113,67 @@ impl SvcUserApp {
         Ok(())
     }
 
-    fn issue_c_get(
+    fn process_cstore_req(
+        msg: &CommandMessage,
         assoc: &mut UserAssoc,
-        mut reader: BufReader<&TcpStream>,
+        mut reader: &mut BufReader<&TcpStream>,
         mut writer: &mut BufWriter<&TcpStream>,
-        query_level: QueryLevel,
-        query: &[(String, String)],
     ) -> Result<Option<DimseMsg>, AssocError> {
-        let msg_id = assoc.next_msg_id();
-        let query_vals_resolved = Self::resolve_cli_query(query)?;
+        let cstore_ctx_id = msg.ctx_id();
+        let cstore_msg_id = msg.msg_id();
+        let cstore_aff_sop = msg.get_string(&AffectedSOPClassUID).unwrap_or_default();
 
-        assoc
-            .common_mut()
-            .c_get_req(&mut writer, msg_id, query_level, query_vals_resolved)?;
-
-        let mut sop_count = 0;
-        let mut cstore_ctx_id: u8 = 0;
-        let mut cstore_msg_id: u16 = 0;
-        let mut cstore_aff_sop: String = String::default();
-        let mut filename = format!("rcv_dcm_{sop_count}.tmp");
+        let filename = "rcv_dcm.tmp";
         let mut output = BufWriter::with_capacity(
             1024 * 1024,
-            File::create(&filename).map_err(|e| AssocError::ab_failure(DimseError::from(e)))?,
+            File::create(filename).map_err(|e| AssocError::ab_failure(DimseError::from(e)))?,
         );
-        loop {
-            match CommonAssoc::next_msg(
-                &mut reader,
-                &mut writer,
-                assoc.common().get_pdu_max_rcv_size(),
-            )? {
-                DimseMsg::Cmd(cmd) => {
-                    // SCP will respond with individual C-STORE requests for each SOP.
-                    if cmd.cmd_type() == &CommandType::CStoreReq {
-                        cstore_ctx_id = cmd.ctx_id();
-                        cstore_msg_id = cmd.msg_id();
-                        cstore_aff_sop = cmd.get_string(&AffectedSOPClassUID).unwrap_or_default();
+        // TODO: Write FileMeta
 
-                        filename = format!("rcv_dcm_{sop_count}.tmp");
-                        output = BufWriter::with_capacity(
-                            1024 * 1024,
-                            File::create(&filename)
-                                .map_err(|e| AssocError::ab_failure(DimseError::from(e)))?,
-                        );
-                        // TODO: Write FileMeta
-                        continue;
-                    }
-                    // SCP may respond with status updates. As long as the status is "pending" this
-                    // should continue to expect C-STORE requests.
-                    if cmd.cmd_type() == &CommandType::CGetRsp && cmd.status().is_pending() {
-                        let progress = SubOpProgress::from(&cmd);
-                        println!(
-                            "C-GET Progress: {}/{}",
-                            progress.0,
-                            progress.0 + progress.1 + progress.2 + progress.3
-                        );
-                        continue;
-                    }
-                    break;
-                }
-                DimseMsg::Dataset(pdv) => {
+        match CommonAssoc::next_msg(
+            &mut reader,
+            &mut writer,
+            assoc.common().get_pdu_max_rcv_size(),
+        )? {
+            DimseMsg::Dataset(pdv) => {
+                output
+                    .write_all(pdv.data())
+                    .map_err(|e| AssocError::ab_failure(DimseError::from(e)))?;
+
+                if pdv.is_last_fragment() {
                     output
-                        .write_all(pdv.data())
+                        .flush()
                         .map_err(|e| AssocError::ab_failure(DimseError::from(e)))?;
+                    let file = output.into_inner().map_err(|e| {
+                        AssocError::ab_failure(DimseError::ApplicationError(e.into()))
+                    })?;
+                    file.sync_all()
+                        .map_err(|e| AssocError::ab_failure(DimseError::from(e)))?;
+                    drop(file);
 
-                    if pdv.is_last_fragment() {
-                        output
-                            .flush()
-                            .map_err(|e| AssocError::ab_failure(DimseError::from(e)))?;
-                        let file = output.into_inner().map_err(|e| {
-                            AssocError::ab_failure(DimseError::ApplicationError(e.into()))
-                        })?;
-                        file.sync_all()
-                            .map_err(|e| AssocError::ab_failure(DimseError::from(e)))?;
-                        drop(file);
+                    let (_pres_ctx, ts) = assoc.common().get_pres_ctx_and_ts(cstore_ctx_id)?;
 
-                        let (_pres_ctx, ts) = assoc.common().get_pres_ctx_and_ts(cstore_ctx_id)?;
+                    rename_file_to_sop(filename, ts).map_err(AssocError::ab_failure)?;
 
-                        rename_file_to_sop(&filename, ts).map_err(AssocError::ab_failure)?;
-
-                        let cmd = CommandMessage::c_store_rsp(
-                            cstore_ctx_id,
-                            cstore_msg_id,
-                            &cstore_aff_sop,
-                            &CommandStatus::success(),
-                        );
-                        CommonAssoc::write_command(
-                            &cmd,
-                            writer,
-                            assoc.common().get_pdu_max_snd_size(),
-                        )?;
-
-                        sop_count += 1;
-                        filename = format!("rcv_dcm_{sop_count}.tmp");
-                        output = BufWriter::with_capacity(
-                            1024 * 1024,
-                            File::create_new(&filename)
-                                .map_err(|e| AssocError::ab_failure(DimseError::from(e)))?,
-                        );
-                    }
+                    let cmd = CommandMessage::c_store_rsp(
+                        cstore_ctx_id,
+                        cstore_msg_id,
+                        &cstore_aff_sop,
+                        &CommandStatus::success(),
+                    );
+                    CommonAssoc::write_command(
+                        &cmd,
+                        writer,
+                        assoc.common().get_pdu_max_snd_size(),
+                    )?;
                 }
-                other => {
-                    eprintln!("Unexpected response: {other:?}");
-                    break;
-                }
+            }
+            other => {
+                return Err(AssocError::error(DimseError::DimseDicomMissing(other)));
             }
         }
 
-        let _ = std::fs::remove_file(&filename);
+        let _ = std::fs::remove_file(filename);
 
         assoc.release_association(&mut reader, &mut writer)
     }
@@ -391,7 +345,21 @@ impl SvcUserApp {
             let msg_id = cmd.msg_id();
 
             // When issuing a C-GET requets the SCP will respond with a C-STORE request.
-            if cmd.cmd_type() == &CommandType::CStoreReq {}
+            if cmd.cmd_type() == &CommandType::CStoreReq {
+                // SCP will respond with individual C-STORE requests for each SOP.
+                Self::process_cstore_req(&cmd, assoc, reader, writer)?;
+                continue;
+            } else if cmd.cmd_type() == &CommandType::CGetRsp && cmd.status().is_pending() {
+                // SCP may respond with status updates. As long as the status is "pending" this
+                // should continue to expect C-STORE requests.
+                let progress = SubOpProgress::from(&cmd);
+                println!(
+                    "C-GET Progress: {}/{}",
+                    progress.0,
+                    progress.0 + progress.1 + progress.2 + progress.3
+                );
+                continue;
+            }
 
             let Some(op) = assoc.common_mut().get_user_op(msg_id) else {
                 return Err(AssocError::ab_failure(DimseError::UnknownMessageID(msg_id)));
@@ -409,9 +377,7 @@ impl SvcUserApp {
                 }
                 AssocUserOp::Get(op) => {
                     op.process_rsp(&mut reader, &mut writer, &cmd)?;
-                    let is_complete = op.is_complete();
-                    if !is_complete {}
-                    is_complete
+                    op.is_complete()
                 }
                 AssocUserOp::Store(op) => {
                     op.process_rsp(&cmd);

--- a/dcmpipe_cli/src/app/scuapp.rs
+++ b/dcmpipe_cli/src/app/scuapp.rs
@@ -319,12 +319,12 @@ impl SvcUserApp {
         match &self.args.cmd {
             SvcUserCommand::Echo => {
                 let msg_id = assoc.next_msg_id();
-                assoc.common_mut().c_echo_rq(&mut writer, msg_id)?;
+                assoc.common_mut().send_cecho_req(&mut writer, msg_id)?;
             }
             SvcUserCommand::Find { query_level, query } => {
                 let msg_id = assoc.next_msg_id();
                 let query_vals_resolved = Self::resolve_cli_query(query)?;
-                assoc.common_mut().c_find_req(
+                assoc.common_mut().send_cfind_req(
                     &mut writer,
                     msg_id,
                     *query_level,
@@ -410,7 +410,7 @@ impl SvcUserApp {
                     is_complete
                 }
                 AssocUserOp::Store(op) => {
-                    op.process_rsp(&mut reader, &mut writer, &cmd)?;
+                    op.process_rsp(&cmd);
                     Self::print_progress(&cmd, "C-STORE");
                     op.is_complete()
                 }
@@ -422,7 +422,7 @@ impl SvcUserApp {
             };
 
             if is_complete {
-                assoc.common_mut().remove_op(msg_id);
+                assoc.common_mut().remove_user_op(msg_id);
                 break;
             }
         }

--- a/dcmpipe_cli/src/app/scuapp.rs
+++ b/dcmpipe_cli/src/app/scuapp.rs
@@ -197,7 +197,11 @@ impl SvcUserApp {
                             &cstore_aff_sop,
                             &CommandStatus::success(),
                         );
-                        assoc.common().write_command(&cmd, &mut writer)?;
+                        CommonAssoc::write_command(
+                            &cmd,
+                            writer,
+                            assoc.common().get_pdu_max_snd_size(),
+                        )?;
 
                         sop_count += 1;
                         filename = format!("rcv_dcm_{sop_count}.tmp");
@@ -389,7 +393,7 @@ impl SvcUserApp {
             // When issuing a C-GET requets the SCP will respond with a C-STORE request.
             if cmd.cmd_type() == &CommandType::CStoreReq {}
 
-            let Some(op) = assoc.common_mut().op(msg_id) else {
+            let Some(op) = assoc.common_mut().get_user_op(msg_id) else {
                 return Err(AssocError::ab_failure(DimseError::UnknownMessageID(msg_id)));
             };
 

--- a/dcmpipe_cli/src/app/scuapp.rs
+++ b/dcmpipe_cli/src/app/scuapp.rs
@@ -255,7 +255,7 @@ impl CommandApplication for SvcUserApp {
             }
             Err(e) => {
                 let _ = e.write(&mut writer);
-                eprintln!("Error: {e:?}");
+                eprintln!("[ err xx] {}", e.err());
             }
         }
         Ok(())

--- a/dcmpipe_lib/src/core/charset.rs
+++ b/dcmpipe_lib/src/core/charset.rs
@@ -71,8 +71,8 @@ impl CSRef {
     /// This is based off `encoding::label::encoding_from_whatwg_label` with a few minor changes
     /// - All whitespace, hyphens, and underscores are stripped when doing a lookup
     /// - Added `ISO-IR-192` mapping for `UTF-8`
-    /// See DICOM Part 2 Appendix D.6.2 Support of Character Sets - Character Sets
-    /// <http://dicom.nema.org/medical/dicom/current/output/chtml/part02/sect_D.6.2.html>
+    ///   See DICOM Part 2 Appendix D.6.2 Support of Character Sets - Character Sets
+    ///   <http://dicom.nema.org/medical/dicom/current/output/chtml/part02/sect_D.6.2.html>
     #[must_use]
     pub fn lookup_charset(label: &str) -> Option<CSRef> {
         let label: String = label

--- a/dcmpipe_lib/src/core/dcmelement.rs
+++ b/dcmpipe_lib/src/core/dcmelement.rs
@@ -292,11 +292,11 @@ impl DicomElement {
     ///
     /// * `value` - The value to be encoded according to `self.vr`.
     /// * `vl` - The value length to use. If `None` then the value length will be computed and
-    /// `ValueLength::Explicit` will be assigned to `self.vl`. If `Some` then it will only be used
-    /// if `self.is_seq_like()` would return true, otherwise the value length will be computed and
-    /// `ValueLength::Explicit` will be assigned to `self.vl`. Unconditionally, `self.vl` will be
-    /// assigned `ValueLength::Explicit(0)` if this element is `Item`, `ItemDelimitationItem`, or
-    /// `SequenceDelimitationItem`.
+    ///   `ValueLength::Explicit` will be assigned to `self.vl`. If `Some` then it will only be used
+    ///   if `self.is_seq_like()` would return true, otherwise the value length will be computed and
+    ///   `ValueLength::Explicit` will be assigned to `self.vl`. Unconditionally, `self.vl` will be
+    ///   assigned `ValueLength::Explicit(0)` if this element is `Item`, `ItemDelimitationItem`, or
+    ///   `SequenceDelimitationItem`.
     ///
     /// # Errors
     /// Encoding string values may fail.

--- a/dcmpipe_lib/src/core/defn/vr.rs
+++ b/dcmpipe_lib/src/core/defn/vr.rs
@@ -60,12 +60,12 @@ pub struct VR {
     ///
     /// Part 5, Ch 6.2:
     /// - Values with VRs constructed of character strings, except
-    /// in the case of the VR UI, shall be padded with SPACE characters
-    /// (20H, in the Default Character Repertoire).
+    ///   in the case of the VR UI, shall be padded with SPACE characters
+    ///   (20H, in the Default Character Repertoire).
     /// - Values with a VR of UI shall be padded with a single trailing
-    /// NULL (00H) character when necessary to achieve even length.
+    ///   NULL (00H) character when necessary to achieve even length.
     /// - Values with a VR of OB shall be padded with a single trailing
-    /// NULL byte value (00H) when necessary to achieve even length.
+    ///   NULL byte value (00H) when necessary to achieve even length.
     pub padding: u8,
 
     /// If this VR is encoded explicitly, then depending on VR there might be a 2-byte padding after
@@ -331,12 +331,12 @@ pub static CS: VR = VR {
 ///
 /// ### Notes
 /// 1. The ACR-NEMA Standard 300 (predecessor to DICOM) supported a
-/// string of characters of the format YYYY.MM.DD for this VR.
-/// Use of this format is not compliant.
+///    string of characters of the format YYYY.MM.DD for this VR.
+///    Use of this format is not compliant.
 /// 2. See also DT VR in this table.
 /// 3. Dates before year 1582, e.g. used for dating historical or
-/// archeological items, are interpreted as proleptic Gregorian calendar
-/// dates, unless otherwise specified.
+///    archeological items, are interpreted as proleptic Gregorian calendar
+///    dates, unless otherwise specified.
 ///
 /// ## Character Repertoire
 /// `'0'`-`'9'` of Default Character Repertoire
@@ -452,16 +452,16 @@ pub static DS: VR = VR {
 ///
 /// ### Notes
 /// 1. The range of the offset is -1200 to +1400. The offset for United States
-/// Eastern Standard Time is -0500.
-/// The offset for Japan Standard Time is +0900.
+///    Eastern Standard Time is -0500.
+///    The offset for Japan Standard Time is +0900.
 /// 2. The RFC 2822 use of -0000 as an offset to indicate local time is
-/// not allowed.
+///    not allowed.
 /// 3. A Date Time value of 195308 means August 1953, not specific to
-/// particular day. A Date Time value of 19530827111300.0 means
-/// August 27, 1953, 11;13 a.m. accurate to 1/10th second.
+///    particular day. A Date Time value of 19530827111300.0 means
+///    August 27, 1953, 11;13 a.m. accurate to 1/10th second.
 /// 4. The Second component may have a value of 60 only for a leap second.
 /// 5. The offset may be included regardless of null components; e.g.,
-/// 2007-0500 is a legal value.
+///    2007-0500 is a legal value.
 ///
 /// ## Character Repertoire
 /// `'0'`-`'9'`, `+`, `-`, `.` and the SPACE character of Default
@@ -999,7 +999,7 @@ pub static SV: VR = VR {
 /// - MM contains minutes (range "00" - "59"),
 /// - SS contains seconds (range "00" - "60"), and
 /// - FFFFFF contains a fractional part of a second as small
-/// as 1 millionth of a second (range "000000" - "999999").
+///   as 1 millionth of a second (range "000000" - "999999").
 ///
 /// A 24-hour clock is used. Midnight shall be represented by only "0000"
 /// since "2400" would violate the hour range. The string may be padded with
@@ -1015,14 +1015,14 @@ pub static SV: VR = VR {
 ///
 /// ### Examples
 /// 1. "070907.0705 " represents a time of 7 hours, 9 minutes and 7.0705
-/// seconds.
+///    seconds.
 /// 2. "1010" represents a time of 10 hours, and 10 minutes.
 /// 3. "021 " is an invalid value.
 ///
 /// ### Notes
 /// 1. The ACR-NEMA Standard 300 (predecessor to DICOM) supported a string of
-/// characters of the format HH:MM:SS.frac for this VR. Use of this format is
-/// not compliant.
+///    characters of the format HH:MM:SS.frac for this VR. Use of this format is
+///    not compliant.
 /// 2. See also DT VR in this table.
 /// 3. The SS component may have a value of 60 only for a leap second.
 ///

--- a/dcmpipe_lib/src/dimse/assoc.rs
+++ b/dcmpipe_lib/src/dimse/assoc.rs
@@ -250,6 +250,8 @@ impl CommonAssoc {
     pub fn get_pdu_max_snd_size(&self) -> usize {
         for user_pdu in &self.their_user_data {
             if let UserPdu::MaxLengthItem(mli) = user_pdu {
+                // TODO: If this value is less than the PDI + PDV header sizes then error, or do
+                //       something else?
                 return usize::try_from(mli.max_length()).unwrap_or_default();
             }
         }
@@ -263,6 +265,8 @@ impl CommonAssoc {
     pub fn get_pdu_max_rcv_size(&self) -> usize {
         for user_pdu in &self.this_user_data {
             if let UserPdu::MaxLengthItem(mli) = user_pdu {
+                // TODO: If this value is less than the PDI + PDV header sizes then error, or do
+                //       something else?
                 return usize::try_from(mli.max_length()).unwrap_or_default();
             }
         }
@@ -641,7 +645,7 @@ impl CommonAssoc {
         origin_ae: &str,
         orig_msg_id: u16,
     ) -> Result<(), AssocError> {
-        let store_op = StoreUserOp::new(store_msg_id, self.get_pdu_max_rcv_size());
+        let store_op = StoreUserOp::new(store_msg_id, self.get_pdu_max_snd_size());
         let (cmd, pdi_iter) =
             store_op.create_req(self, parser, store_msg_id, origin_ae, orig_msg_id)?;
 

--- a/dcmpipe_lib/src/dimse/assoc.rs
+++ b/dcmpipe_lib/src/dimse/assoc.rs
@@ -230,9 +230,9 @@ impl CommonAssoc {
             .iter()
             .find(|(_ctx_id, (_pres_ctx, abs_uid))| *abs_uid == ab_ref)
         else {
-            return Err(AssocError::ab_failure(DimseError::UnknownAbstractSyntax(
-                ab_ref.uid().to_owned(),
-            )));
+            return Err(AssocError::ab_failure(
+                DimseError::UnsupportedAbstractSyntax { uid: ab_ref },
+            ));
         };
 
         let ts_bytes = pres_ctx.transfer_syntax().transfer_syntaxes();

--- a/dcmpipe_lib/src/dimse/assoc/scp.rs
+++ b/dcmpipe_lib/src/dimse/assoc/scp.rs
@@ -126,7 +126,7 @@ impl ServiceAssoc {
     ///
     /// # Errors
     /// - If the result of the request is to reject or abort, those are propagated as an
-    /// `AssocError`.
+    ///   `AssocError`.
     fn validate_assoc_rq(
         &mut self,
         rq: &AssocRQ,

--- a/dcmpipe_lib/src/dimse/assoc/scp.rs
+++ b/dcmpipe_lib/src/dimse/assoc/scp.rs
@@ -358,7 +358,8 @@ impl ServiceAssocBuilder {
 
             their_user_data: Vec::with_capacity(num_user_data),
             negotiated_pres_ctx: HashMap::with_capacity(num_abs),
-            active_ops: HashMap::new(),
+            active_user_ops: HashMap::new(),
+            active_svc_ops: HashMap::new(),
         };
 
         ServiceAssoc {

--- a/dcmpipe_lib/src/dimse/assoc/scp.rs
+++ b/dcmpipe_lib/src/dimse/assoc/scp.rs
@@ -65,6 +65,7 @@ impl ServiceAssoc {
         self.accept_aets.is_empty() || self.accept_aets.contains_key(aet)
     }
 
+    /// Gets the connection info for a known AE Title.
     #[must_use]
     pub fn aet_host(&self, aet: &str) -> Option<&String> {
         self.accept_aets.get(aet)

--- a/dcmpipe_lib/src/dimse/assoc/scu.rs
+++ b/dcmpipe_lib/src/dimse/assoc/scu.rs
@@ -74,7 +74,7 @@ impl UserAssoc {
     /// # Errors
     /// - I/O errors may occur with the reader/writer.
     /// - `DimseError` may be returned if: an unexpected PDU was received during negotiation, or if
-    /// no presentation contexts could be negotiated.
+    ///   no presentation contexts could be negotiated.
     pub fn request_association<R: Read, W: Write>(
         &mut self,
         reader: R,

--- a/dcmpipe_lib/src/dimse/assoc/scu.rs
+++ b/dcmpipe_lib/src/dimse/assoc/scu.rs
@@ -265,7 +265,8 @@ impl UserAssocBuilder {
             this_user_data,
             their_user_data: Vec::with_capacity(num_user_data),
             negotiated_pres_ctx: HashMap::with_capacity(num_abs),
-            active_ops: HashMap::new(),
+            active_user_ops: HashMap::new(),
+            active_svc_ops: HashMap::new(),
         };
 
         UserAssoc {

--- a/dcmpipe_lib/src/dimse/error.rs
+++ b/dcmpipe_lib/src/dimse/error.rs
@@ -43,6 +43,11 @@ pub enum DimseError {
     #[error("application error: {0}")]
     ApplicationError(Box<dyn std::error::Error>),
 
+    /// A PDU type was encountered that is unknown, likely non-standard or a corruption in the
+    /// stream.
+    #[error("invalid pdu type: {0:04X}")]
+    InvalidPduType(u8),
+
     /// Error while parsing a DICOM element in a DIMSE request/response.
     #[error("error parsing value from request: {0}")]
     ParseError(#[from] ParseError),
@@ -59,14 +64,8 @@ pub enum DimseError {
     #[error("i/o error reading from dataset: {0}")]
     IOError(#[from] std::io::Error),
 
-    /// A PDU type was encountered that is unknown, likely non-standard or a corruption in the
-    /// straem.
-    #[error("invalid pdu type: {0:04X}")]
-    InvalidPduType(u8),
-
-    /// An AE Title which is not correctly formatted.
-    #[error("invalid ae title: {0}")]
-    InvalidAeTitle(String),
+    #[error("malformed ae title: {0}")]
+    MalformedAeTitle(String),
 
     #[error("called ae title is not this ae title: {0}")]
     InvalidCalledAeTitle(String),
@@ -105,9 +104,6 @@ pub enum DimseError {
 
     #[error("maximum pdu size exceeded, PDU is {0} bytes")]
     MaxPduSizeExceeded(usize),
-
-    #[error("DICOM file is missing SOP Instance UID (bytes read: {0}): {1}")]
-    SOPInstanceUIDMissing(usize, String),
 
     #[error("Association negotiation failed: {0}")]
     AssocNegotiationFailure(String),

--- a/dcmpipe_lib/src/dimse/error.rs
+++ b/dcmpipe_lib/src/dimse/error.rs
@@ -99,8 +99,8 @@ pub enum DimseError {
     #[error("dimse query parsing failed")]
     QueryParseError,
 
-    #[error("unsupported abstract syntax {0:?}")]
-    UnsupportedAbstractSyntax(UIDRef),
+    #[error("unsupported abstract syntax {}", uid.name())]
+    UnsupportedAbstractSyntax { uid: UIDRef },
 
     #[error("maximum pdu size exceeded, PDU is {0} bytes")]
     MaxPduSizeExceeded(usize),
@@ -161,6 +161,11 @@ impl AssocError {
     #[must_use]
     pub fn rsp(&self) -> &Option<AssocRsp> {
         &self.rsp
+    }
+
+    #[must_use]
+    pub fn err(&self) -> &DimseError {
+        &self.err
     }
 
     #[must_use]

--- a/dcmpipe_lib/src/dimse/mod.rs
+++ b/dcmpipe_lib/src/dimse/mod.rs
@@ -38,7 +38,7 @@ impl TryFrom<&[u8]> for AeTitle {
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         if value.is_empty() || value.len() > 16 {
-            return Err(DimseError::InvalidAeTitle(
+            return Err(DimseError::MalformedAeTitle(
                 String::from_utf8(value.to_vec()).unwrap_or_default(),
             ));
         }
@@ -47,7 +47,7 @@ impl TryFrom<&[u8]> for AeTitle {
         let () = &mut filled_ae[0..value.len()].copy_from_slice(value);
         TryInto::<[u8; 16]>::try_into(filled_ae)
             .map(AeTitle::from)
-            .map_err(|val| DimseError::InvalidAeTitle(String::from_utf8(val).unwrap_or_default()))
+            .map_err(|val| DimseError::MalformedAeTitle(String::from_utf8(val).unwrap_or_default()))
     }
 }
 

--- a/dcmpipe_lib/src/dimse/pdus/pduiter.rs
+++ b/dcmpipe_lib/src/dimse/pdus/pduiter.rs
@@ -252,7 +252,9 @@ where
     ///
     /// # Params
     /// `ctx_id` - The `ctx_id` that each resulting `PresentationDataItem` will be assocaited with.
-    /// `max_pdu_size` - The maximum size of each `PresentationDataItem`, in bytes.
+    /// `max_pdu_size` - The maximum size of each `PresentationDataItem`, in bytes. This should be
+    ///                  either zero to indicate no maximum, or a value greater than the sum of the
+    ///                  PDI and PDV header sizes.
     /// `is_command` - Whether this is for command messages or for DICOM datasets.
     /// `elements` - The iterator over elements to convert.
     /// `ts` - The transfer syntax that the elements should be written with.
@@ -266,6 +268,13 @@ where
         ts: TSRef,
         cs: CSRef,
     ) -> Self {
+        let header_size =
+            PresentationDataItem::header_byte_size() + PresentationDataValue::header_byte_size();
+        let max_pdu_size = if max_pdu_size == 0 {
+            usize::MAX - header_size
+        } else {
+            max_pdu_size - header_size
+        };
         let max_payload_size = max_pdu_size
             - PresentationDataItem::header_byte_size()
             - PresentationDataValue::header_byte_size();

--- a/dcmpipe_lib/src/dimse/pdus/pduiter.rs
+++ b/dcmpipe_lib/src/dimse/pdus/pduiter.rs
@@ -47,9 +47,9 @@ use crate::{
 
 pub fn read_next_pdu<R: Read>(
     reader: R,
-    max_pdu_size: usize,
+    max_pdu_rcv_size: usize,
 ) -> Option<Result<PduIterItem, DimseError>> {
-    PduIter::new(reader, max_pdu_size).next()
+    PduIter::new(reader, max_pdu_rcv_size).next()
 }
 
 #[derive(Debug)]

--- a/dcmpipe_lib/src/dimse/userops.rs
+++ b/dcmpipe_lib/src/dimse/userops.rs
@@ -329,14 +329,8 @@ impl StoreUserOp {
         Ok((cmd, pdi_iter))
     }
 
-    pub fn process_rsp<R: Read, W: Write>(
-        &mut self,
-        mut _reader: R,
-        mut _writer: W,
-        msg: &CommandMessage,
-    ) -> Result<(), AssocError> {
+    pub fn process_rsp(&mut self, msg: &CommandMessage) {
         self.is_complete |= !msg.status().is_pending();
-        Ok(())
     }
 }
 

--- a/dcmpipe_lib/tests/parsing.rs
+++ b/dcmpipe_lib/tests/parsing.rs
@@ -163,8 +163,8 @@ mod parsing_tests {
         let mut parser: Parser<'_, MockDicomDataset> =
             MockDicomDataset::build_mock_parser(&[STANDARD_HEADER, NULL_ELEMENT]);
 
-        let first_non_fme: Option<std::result::Result<DicomElement, ParseError>> = parser
-            .find(|x| !x.is_ok() || x.as_ref().unwrap().tag() > SpecificCharacterSet.tag);
+        let first_non_fme: Option<std::result::Result<DicomElement, ParseError>> =
+            parser.find(|x| !x.is_ok() || x.as_ref().unwrap().tag() > SpecificCharacterSet.tag);
 
         assert!(first_non_fme.is_none());
     }


### PR DESCRIPTION
Operations are now separated into their own structure, and the request/response(s) are managed independent of each other. This will enable handling operations in an asynchronous manner.